### PR TITLE
Investigate unreleased threads causing thread limit

### DIFF
--- a/ai_ta_backend/service/retrieval_service.py
+++ b/ai_ta_backend/service/retrieval_service.py
@@ -111,14 +111,14 @@ class RetrievalService:
       else:
         embedding_client = self.embeddings
 
-      # Create tasks for parallel execution
-      with self.thread_pool_executor as executor:
-        loop = asyncio.get_event_loop()
-        tasks = [
-            loop.run_in_executor(executor, self.sqlDb.getDisabledDocGroups, course_name),
-            loop.run_in_executor(executor, self.sqlDb.getPublicDocGroups, course_name),
-            loop.run_in_executor(executor, self._embed_query_and_measure_latency, search_query, embedding_client)
-        ]
+      # Create tasks for parallel execution using the shared thread pool (do not shut it down per request)
+      loop = asyncio.get_event_loop()
+      executor = self.thread_pool_executor.executor
+      tasks = [
+          loop.run_in_executor(executor, self.sqlDb.getDisabledDocGroups, course_name),
+          loop.run_in_executor(executor, self.sqlDb.getPublicDocGroups, course_name),
+          loop.run_in_executor(executor, self._embed_query_and_measure_latency, search_query, embedding_client)
+      ]
 
       disabled_doc_groups_response, public_doc_groups_response, user_query_embedding = await asyncio.gather(*tasks)
 


### PR DESCRIPTION
Stop shutting down the shared thread pool in `getTopContexts` to prevent thread churn and "can't start new thread" errors.

The `ThreadPoolExecutorAdapter` was being used as a context manager in `getTopContexts`, which caused its `__exit__` method to call `shutdown()` on the underlying `ThreadPoolExecutor` after every request. This constant recreation and shutdown of the thread pool under load was identified as the primary cause of the "can't start new thread" error on Railway. This change ensures the shared executor remains long-lived.

---
<a href="https://cursor.com/background-agent?bcId=bc-23a74ecf-b4c6-4e8a-8a3d-77dfaea48df1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23a74ecf-b4c6-4e8a-8a3d-77dfaea48df1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

