### PR TITLE
Fix allDocs filter

### DIFF
--- a/ai_ta_backend/database/sql.py
+++ b/ai_ta_backend/database/sql.py
@@ -112,12 +112,7 @@ class SQLDatabase:
 
     def getAllMaterialsForCourse(self, course_name: str):
         query = (
-            select(models.Document.course_name,
-                   models.Document.s3_path,
-                   models.Document.readable_filename,
-                   models.Document.url,
-                   models.Document.base_url
-                   )
+            select(models.Document)
             .where(models.Document.course_name == course_name)
         )
         with self.get_session() as session:


### PR DESCRIPTION
The query was only returning a list of course_names instead of the whole document, causing parsing errors after.