### PR TITLE
Memory diagnostics

### DIFF
--- a/ai_ta_backend/main.py
+++ b/ai_ta_backend/main.py
@@ -3,6 +3,8 @@ import os
 import re
 import time
 import logging
+import gc
+import tracemalloc
 from typing import List
 
 from dotenv import load_dotenv
@@ -56,6 +58,17 @@ executor = Executor(app)
 # load API keys from globally-availabe .env file
 load_dotenv()
 
+# Lightweight, opt-in memory diagnostics
+TRACEMALLOC_ENABLED = os.getenv('TRACEMALLOC_ENABLED', 'false').lower() == 'true'
+_tracemalloc_started = False
+_baseline_snapshot = None
+
+def _ensure_tracemalloc_started():
+  global _tracemalloc_started
+  if not _tracemalloc_started:
+    tracemalloc.start(25)
+    _tracemalloc_started = True
+
 
 @app.route('/')
 def index() -> Response:
@@ -87,6 +100,71 @@ def health() -> Response:
   })
   response.headers.add('Access-Control-Allow-Origin', '*')
   return response
+
+
+@app.route('/debug/mem/start', methods=['POST'])
+def mem_start() -> Response:
+  if not TRACEMALLOC_ENABLED:
+    return jsonify({"enabled": False}), 403
+  _ensure_tracemalloc_started()
+  global _baseline_snapshot
+  gc.collect()
+  _baseline_snapshot = tracemalloc.take_snapshot()
+  return jsonify({"enabled": True, "status": "started"})
+
+
+@app.route('/debug/mem/stop', methods=['POST'])
+def mem_stop() -> Response:
+  if not TRACEMALLOC_ENABLED:
+    return jsonify({"enabled": False}), 403
+  global _tracemalloc_started, _baseline_snapshot
+  if _tracemalloc_started:
+    tracemalloc.stop()
+  _tracemalloc_started = False
+  _baseline_snapshot = None
+  return jsonify({"enabled": True, "status": "stopped"})
+
+
+@app.route('/debug/mem/heap', methods=['GET'])
+def mem_heap() -> Response:
+  if not TRACEMALLOC_ENABLED:
+    return jsonify({"enabled": False}), 403
+  _ensure_tracemalloc_started()
+  current, peak = tracemalloc.get_traced_memory()
+  return jsonify({
+    "enabled": True,
+    "current_bytes": int(current),
+    "peak_bytes": int(peak)
+  })
+
+
+@app.route('/debug/mem/stats', methods=['GET'])
+def mem_stats() -> Response:
+  if not TRACEMALLOC_ENABLED:
+    return jsonify({"enabled": False}), 403
+  _ensure_tracemalloc_started()
+  gc.collect()
+  global _baseline_snapshot
+  snap = tracemalloc.take_snapshot()
+  if _baseline_snapshot is not None:
+    stats = snap.compare_to(_baseline_snapshot, 'lineno')
+  else:
+    stats = snap.statistics('lineno')
+  top_n = int(os.getenv('TRACEMALLOC_TOP', '25'))
+  top = []
+  for s in stats[:top_n]:
+    top.append({
+      "trace": str(s.traceback).split('\n')[-1].strip(),
+      "size_bytes": int(s.size),
+      "count": int(s.count)
+    })
+  total = sum(int(s.size) for s in stats)
+  return jsonify({
+    "enabled": True,
+    "total_bytes": int(total),
+    "top": top,
+    "baseline": _baseline_snapshot is not None
+  })
 
 
 @app.route('/getTopContexts', methods=['POST'])


### PR DESCRIPTION
# Memory Diagnostics Feature

## Overview

This PR adds opt-in memory diagnostics to the Backend using Python's built-in `tracemalloc` module. The feature provides runtime memory monitoring and profiling capabilities without requiring external dependencies or significant performance overhead when disabled.

## Motivation

Monitoring memory usage in production environments is critical for:
- Identifying memory leaks and excessive memory consumption
- Debugging performance issues related to memory
- Tracking memory patterns over time
- Comparing memory usage before and after specific operations

### Dependencies Added

None - uses only Python standard library modules:
- `gc` - Garbage collection utilities
- `tracemalloc` - Memory allocation tracing

## Implementation Details

### Configuration

The feature is controlled by environment variables:

- `TRACEMALLOC_ENABLED` (default: `false`) - Enable/disable memory diagnostics
- `TRACEMALLOC_TOP` (default: `25`) - Number of top memory allocation sites to return

### Endpoints Added

#### 1. POST `/debug/mem/start`

Initializes memory tracing and establishes a baseline snapshot.

**Request:**
```bash
POST /debug/mem/start
```

**Response:**
```json
{
  "enabled": true,
  "status": "started"
}
```

**Behavior:**
- Performs garbage collection to ensure clean baseline
- Takes initial memory snapshot for comparison
- Returns 403 if feature is not enabled

---

#### 2. POST `/debug/mem/stop`

Stops memory tracing and clears the baseline snapshot.

**Request:**
```bash
POST /debug/mem/stop
```

**Response:**
```json
{
  "enabled": true,
  "status": "stopped"
}
```

**Behavior:**
- Stops tracemalloc tracing
- Clears stored baseline snapshot
- Returns 403 if feature is not enabled

---

#### 3. GET `/debug/mem/heap`

Returns current and peak memory usage statistics.

**Request:**
```bash
GET /debug/mem/heap
```

**Response:**
```json
{
  "enabled": true,
  "current_bytes": 12345678,
  "peak_bytes": 23456789
}
```

**Behavior:**
- Returns current traced memory in bytes
- Returns peak traced memory in bytes
- Automatically starts tracing if not already started
- Returns 403 if feature is not enabled

---

#### 4. GET `/debug/mem/stats`

Returns detailed memory allocation statistics.

**Request:**
```bash
GET /debug/mem/stats
```

**Response:**
```json
{
  "enabled": true,
  "total_bytes": 98765432,
  "baseline": true,
  "top": [
    {
      "trace": "file_name.py:123:function_name",
      "size_bytes": 1234567,
      "count": 42
    },
    ...
  ]
}
```

**Behavior:**
- Performs garbage collection before taking snapshot
- Compares against baseline if available
- Returns top N allocation sites (controlled by `TRACEMALLOC_TOP`)
- Includes total memory usage across all traces
- Returns 403 if feature is not enabled

## Usage Example

### Enable the Feature

```bash
export TRACEMALLOC_ENABLED=true
export TRACEMALLOC_TOP=10
```

### Monitor Memory Usage

```bash
# Start tracking
curl -X POST http://localhost:8000/debug/mem/start

# Perform some operations...
# (execute various API calls)

# Check heap usage
curl http://localhost:8000/debug/mem/heap

# Get detailed statistics
curl http://localhost:8000/debug/mem/stats

# Stop tracking
curl -X POST http://localhost:8000/debug/mem/stop
```

## Security Considerations

- All debug endpoints return 403 Forbidden when `TRACEMALLOC_ENABLED` is false
- No authentication is currently implemented - this should be added for production use
- Consider restricting access to these endpoints via network-level controls
- Sensitive information may be present in traceback outputs

## Performance Impact

- **When disabled** (`TRACEMALLOC_ENABLED=false`): Zero overhead - all endpoints return 403 immediately
- **When enabled** (`TRACEMALLOC_ENABLED=true`): 
  - Initial overhead from starting tracemalloc
  - Ongoing overhead from tracking allocations (typically 10-20% slower)
  - Garbage collection calls add minimal overhead
  - Snapshots are lightweight operations

## Best Practices

1. **Enable only when needed**: Keep `TRACEMALLOC_ENABLED=false` in production unless actively debugging
2. **Establish baseline**: Always call `/debug/mem/start` before the operation you want to analyze
3. **Clean state**: Call `/debug/mem/stop` when done to clear baseline and reduce memory overhead
4. **Monitor heap first**: Use `/debug/mem/heap` for quick checks before diving into detailed stats
5. **Limit top results**: Set `TRACEMALLOC_TOP` to a reasonable number (10-50) to avoid overwhelming output

## Testing

To test the feature:

```bash
# Enable tracing
export TRACEMALLOC_ENABLED=true

# Start the server
python ai_ta_backend/main.py

# In another terminal, start memory tracking
curl -X POST http://localhost:8000/debug/mem/start

# Make some API calls...

# Check memory usage
curl http://localhost:8000/debug/mem/heap
curl http://localhost:8000/debug/mem/stats

# Stop tracking
curl -X POST http://localhost:8000/debug/mem/stop
```