### PR TITLE
Unify minio endpoint env var

### DIFF
--- a/ai_ta_backend/database/aws.py
+++ b/ai_ta_backend/database/aws.py
@@ -11,8 +11,8 @@ class AWSStorage:
     s3_config = {}
 
     # If running against local MinIO
-    if os.environ.get("LOCAL_MINIO") == "true" and os.environ.get("MINIO_ENDPOINT"):
-        s3_config["endpoint_url"] = os.environ["MINIO_ENDPOINT"]
+    if os.environ.get("LOCAL_MINIO") == "true" and os.environ.get("MINIO_URL"):
+        s3_config["endpoint_url"] = os.environ["MINIO_URL"]
     
     # AWS credentials
     if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):

--- a/ai_ta_backend/rabbitmq/ingest.py
+++ b/ai_ta_backend/rabbitmq/ingest.py
@@ -88,6 +88,9 @@ class Ingest:
         # Temporarily raise indexing threshold during ingestion, then revert
         self.qdrant_indexing_threshold_ingest = int(os.getenv('QDRANT_INDEXING_THRESHOLD_INGEST', '100000000'))
         self.qdrant_indexing_threshold_online = int(os.getenv('QDRANT_INDEXING_THRESHOLD_ONLINE', '1000'))
+        
+        # Embedding API retry configuration
+        self.embedding_max_attempts = int(os.getenv('EMBEDDING_MAX_ATTEMPTS', '10'))
 
     def initialize_resources(self):
         # Initialize Qdrant client and create collection if necessary
@@ -377,7 +380,7 @@ class Ingest:
                 max_requests_per_minute=10_000,
                 max_tokens_per_minute=10_000_000,
                 token_encoding_name='cl100k_base',
-                max_attempts=1_000,
+                max_attempts=self.embedding_max_attempts,
                 logging_level=logging.INFO,
                 model=self.embedding_model)
             asyncio.run(oai.process_api_requests_from_file())

--- a/ai_ta_backend/rabbitmq/worker.py
+++ b/ai_ta_backend/rabbitmq/worker.py
@@ -16,6 +16,7 @@ app = Flask(__name__)
 
 BACKOFF_BASE = float(os.getenv('BACKOFF_BASE', '1.0'))   # seconds
 BACKOFF_MAX  = float(os.getenv('BACKOFF_MAX', '30.0'))   # seconds
+PREFETCH_COUNT = int(os.getenv('RABBITMQ_PREFETCH_COUNT', '1'))  # messages
 
 stop_event = threading.Event()
 worker_thread: threading.Thread | None = None
@@ -50,6 +51,7 @@ class Worker:
         self.connection = pika.BlockingConnection(parameters)
         self.channel = self.connection.channel()
         self.channel.queue_declare(queue=self.rabbitmq_queue, durable=True)
+        self.channel.basic_qos(prefetch_count=PREFETCH_COUNT)
 
     def close(self):
         try:

--- a/ai_ta_backend/utils/pubmed_extraction.py
+++ b/ai_ta_backend/utils/pubmed_extraction.py
@@ -26,7 +26,7 @@ from posthog import Posthog
 #     supabase_key=os.getenv('SUPABASE_API_KEY')  # type: ignore
 # )
 
-# MINIO_CLIENT = Minio(os.environ['MINIO_ENDPOINT'],
+# MINIO_CLIENT = Minio(os.environ['MINIO_URL'],
 #                      access_key=os.environ['MINIO_ACCESS_KEY'],
 #                      secret_key=os.environ['MINIO_SECRET'],
 #                      secure=True)
@@ -52,7 +52,7 @@ def extractPubmedData():
         )
 
   if 'MINIO_CLIENT' not in globals():
-        MINIO_CLIENT = Minio(os.environ['MINIO_ENDPOINT'],
+        MINIO_CLIENT = Minio(os.environ['MINIO_URL'],
                             access_key=os.environ['MINIO_ACCESS_KEY'],
                             secret_key=os.environ['MINIO_SECRET'],
                             secure=True)

--- a/ai_ta_backend/utils/pubmed_vectorize.py
+++ b/ai_ta_backend/utils/pubmed_vectorize.py
@@ -73,7 +73,7 @@ def extract_text_from_pdf(file_path, s3_path):
 def process_pdf(key, bucket, temp_dir):
     """Process a single PDF file - for parallel execution"""
     minio_client = Minio(
-        endpoint=os.environ['MINIO_ENDPOINT'],
+        endpoint=os.environ['MINIO_URL'],
         access_key=os.environ['MINIO_ACCESS_KEY'],
         secret_key=os.environ['MINIO_SECRET_KEY'],
         secure=os.environ.get('MINIO_SECURE', 'false').lower() == 'true'
@@ -103,7 +103,7 @@ class MinioClient:
     def __init__(self):
         """Initialize MinIO client."""
         self.client = Minio(
-            endpoint=os.environ['MINIO_ENDPOINT'],
+            endpoint=os.environ['MINIO_URL'],
             access_key=os.environ['MINIO_ACCESS_KEY'],
             secret_key=os.environ['MINIO_SECRET_KEY'],
             secure=os.environ.get('MINIO_SECURE', 'false').lower() == 'true'


### PR DESCRIPTION
I realized the backend is using the environment variable `MINIO_ENDPOINT` instead of `MINIO_URL`, which is what the ingest worker expects. This mismatch has been causing confusion when testing locally.

Interestingly, based on the task definitions:
- The ingest worker doesn’t have MINIO_URL defined in its [task definition](https://us-east-2.console.aws.amazon.com/ecs/v2/task-definitions/ingest-worker/24/json?region=us-east-2), suggesting that AWS may be automatically determining the endpoint URL.
- The backend, on the other hand, defines `MINIO_URL` mapped to the parameter store path `/ilchat/ecs/minio/MINIO_ENDPOINT`. However, since the backend code looks for `MINIO_ENDPOINT`, it’s likely that the variable was never actually populated correctly.