### PR TITLE
Qdrant indexing threshold

### DIFF
--- a/ai_ta_backend/rabbitmq/ingest.py
+++ b/ai_ta_backend/rabbitmq/ingest.py
@@ -89,7 +89,7 @@ class Ingest:
         # Qdrant ingestion tuning
         # Batch size for upserts during ingestion per guidance from Qdrant team
         self.qdrant_upsert_batch_size = int(os.getenv('QDRANT_UPSERT_BATCH_SIZE', '100'))
-        # Temporarily raise indexing threshold during ingestion, then revert
+        # Threshold values retained for reference; worker-side toggling is disabled.
         self.qdrant_indexing_threshold_ingest = int(os.getenv('QDRANT_INDEXING_THRESHOLD_INGEST', '100000000'))
         self.qdrant_indexing_threshold_online = int(os.getenv('QDRANT_INDEXING_THRESHOLD_ONLINE', '1000'))
         
@@ -398,16 +398,20 @@ class Ingest:
                 item[0]['input']: item[1]['data'][0]['embedding'] for item in oai.results
             }
 
-            # Batched upload to Qdrant with temporary indexing threshold adjustments
+            # Batched upload to Qdrant. The temporary indexing_threshold toggles are
+            # intentionally disabled because multiple ingest workers can trigger
+            # excess temporary segment growth and disk usage until Qdrant restarts.
             collection_name = os.environ['QDRANT_COLLECTION_NAME']  # type: ignore
-            # Raise indexing threshold to postpone indexing during bulk upserts
-            try:
-                self.qdrant_client.update_collection(
-                    collection_name=collection_name,
-                    optimizer_config=models.OptimizersConfigDiff(indexing_threshold=self.qdrant_indexing_threshold_ingest),
-                )
-            except Exception as e:
-                logging.warning("Could not raise Qdrant indexing threshold before ingestion: %s", e)
+            # Raise indexing threshold to postpone indexing during bulk upserts.
+            # Disabled because concurrent workers can amplify temporary segment and
+            # disk growth until Qdrant is restarted.
+            # try:
+            #     self.qdrant_client.update_collection(
+            #         collection_name=collection_name,
+            #         optimizer_config=models.OptimizersConfigDiff(indexing_threshold=self.qdrant_indexing_threshold_ingest),
+            #     )
+            # except Exception as e:
+            #     logging.warning("Could not raise Qdrant indexing threshold before ingestion: %s", e)
 
             try:
                 batch: list[PointStruct] = []
@@ -443,14 +447,17 @@ class Ingest:
                     except Exception as e:
                         logging.warning("Final batch upsert encountered an error (continuing): %s", e)
             finally:
-                # Revert indexing threshold back to online value
-                try:
-                    self.qdrant_client.update_collection(
-                        collection_name=collection_name,
-                        optimizer_config=models.OptimizersConfigDiff(indexing_threshold=self.qdrant_indexing_threshold_online),
-                    )
-                except Exception as e:
-                    logging.warning("Could not revert Qdrant indexing threshold after ingestion: %s", e)
+                # Revert indexing threshold back to online value.
+                # Disabled because concurrent workers can amplify temporary segment
+                # and disk growth until Qdrant is restarted.
+                # try:
+                #     self.qdrant_client.update_collection(
+                #         collection_name=collection_name,
+                #         optimizer_config=models.OptimizersConfigDiff(indexing_threshold=self.qdrant_indexing_threshold_online),
+                #     )
+                # except Exception as e:
+                #     logging.warning("Could not revert Qdrant indexing threshold after ingestion: %s", e)
+                pass
 
             # Supabase SQL insertion
             # contexts_for_supa = [{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disable Qdrant indexing threshold updates in the ingest worker to prevent temporary segment and disk usage increases caused by concurrent workers.

[Slack Thread](https://ncsa-at-illinois.slack.com/archives/C08QAEAMEB0/p1773156791820439?thread_ts=1773156791.820439&cid=C08QAEAMEB0)

<div><a href="https://cursor.com/agents/bc-b300a1b8-b727-5729-b088-b3908195f1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b300a1b8-b727-5729-b088-b3908195f1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->